### PR TITLE
add commits-since-release

### DIFF
--- a/commits-since-release
+++ b/commits-since-release
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
 
 git fetch
-git log $(git describe --tags --abbrev=0)..origin/master --oneline | wc -l
+num_commits=`git log $(git describe --tags --abbrev=0)..origin/master --oneline | wc -l`
+echo $num_commits
+
+if [ "$num_commits" = "0" ]; then 
+  exit 1
+else 
+  exit 0
+fi

--- a/commits-since-release
+++ b/commits-since-release
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+git fetch
+git log $(git describe --tags --abbrev=0)..origin/master --oneline | wc -l


### PR DESCRIPTION
Usage: 

When in a repository with submodules: `subs commits-since-release` 

Otherwise, simply, `commits-since-release`